### PR TITLE
examples: drop redundant imports and libs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+  pull_request:
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/examples/ftpget/FtpGet.lean
+++ b/examples/ftpget/FtpGet.lean
@@ -1,4 +1,3 @@
-import Lean.Data.Json
 import Curl
 
 open Lean

--- a/examples/ftpget/lakefile.lean
+++ b/examples/ftpget/lakefile.lean
@@ -7,8 +7,6 @@ def libCurl := match get_config? libCurl with | some v => v | _ => "-lcurl"
 
 require Curl from "../../"
 
-lean_lib FtpGet
-
 @[default_target]
 lean_exe ftpget {
   root := `FtpGet

--- a/examples/ftpget/lean-toolchain
+++ b/examples/ftpget/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.11.0
+leanprover/lean4:v4.13.0

--- a/examples/httpdelete/HttpDelete.lean
+++ b/examples/httpdelete/HttpDelete.lean
@@ -1,4 +1,3 @@
-import Lean.Data.Json
 import Curl
 
 open Lean

--- a/examples/httpdelete/lakefile.lean
+++ b/examples/httpdelete/lakefile.lean
@@ -7,8 +7,6 @@ def libCurl := match get_config? libCurl with | some v => v | _ => "-lcurl"
 
 require Curl from "../../"
 
-lean_lib HttpDelete
-
 @[default_target]
 lean_exe httpdelete {
   root := `HttpDelete

--- a/examples/httpdelete/lean-toolchain
+++ b/examples/httpdelete/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.11.0
+leanprover/lean4:v4.13.0

--- a/examples/httpget/lakefile.lean
+++ b/examples/httpget/lakefile.lean
@@ -9,8 +9,6 @@ def buildType := match get_config? buildType with | some "debug" => Lake.BuildTy
 
 require Curl from "../../" with NameMap.empty |>.insert (Name.mkSimple "buildType") (if buildType = .debug then "debug" else "release")
 
-lean_lib HttpGet
-
 @[default_target]
 lean_exe httpget {
   buildType := buildType

--- a/examples/httpget/lean-toolchain
+++ b/examples/httpget/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.11.0
+leanprover/lean4:v4.13.0

--- a/examples/httppost/lakefile.lean
+++ b/examples/httppost/lakefile.lean
@@ -7,8 +7,6 @@ def libCurl := match get_config? libCurl with | some v => v | _ => "-lcurl"
 
 require Curl from "../../"
 
-lean_lib HttpPost
-
 @[default_target]
 lean_exe httppost {
   root := `HttpPost

--- a/examples/httppost/lean-toolchain
+++ b/examples/httppost/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.11.0
+leanprover/lean4:v4.13.0

--- a/examples/httpput/lakefile.lean
+++ b/examples/httpput/lakefile.lean
@@ -9,8 +9,6 @@ def buildType := match get_config? buildType with | some "debug" => Lake.BuildTy
 
 require Curl from "../../" with NameMap.empty |>.insert (Name.mkSimple "buildType") (if buildType = .debug then "debug" else "release")
 
-lean_lib HttpPut
-
 @[default_target]
 lean_exe httpput {
   buildType := buildType

--- a/examples/reservoir-index/Main.lean
+++ b/examples/reservoir-index/Main.lean
@@ -12,7 +12,6 @@ open Curl
 -/
 
 open IO.Process
-open Lean
 
 structure Source where
   repoUrl : String

--- a/examples/reservoir-index/lakefile.lean
+++ b/examples/reservoir-index/lakefile.lean
@@ -9,8 +9,6 @@ def buildType := match get_config? buildType with | some "debug" => Lake.BuildTy
 
 require Curl from "../../" with NameMap.empty |>.insert (Name.mkSimple "buildType") (if buildType = .debug then "debug" else "release")
 
-lean_lib ReservoirIndex
-
 @[default_target]
 lean_exe index {
   buildType := buildType

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.11.0
+leanprover/lean4:v4.13.0


### PR DESCRIPTION
Just some trivial simplifications to the examples - nothing interesting.

Thanks for making this project - it's really useful!